### PR TITLE
Enable custom test list

### DIFF
--- a/api-tests/CMakeLists.txt
+++ b/api-tests/CMakeLists.txt
@@ -590,7 +590,7 @@ ExternalProject_Add(
         DOWNLOAD_COMMAND ""
         UPDATE_COMMAND ""
         PATCH_COMMAND ""
-        BUILD_COMMAND ""
+        BUILD_ALWAYS TRUE
         SOURCE_DIR "${PSA_ROOT_DIR}/tools/scripts/target_cfg"
 	CMAKE_ARGS -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
 		-DOUT_DIR=${CMAKE_CURRENT_BINARY_DIR}

--- a/api-tests/CMakeLists.txt
+++ b/api-tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 #/** @file
 # * Copyright (c) 2019-2022, Arm Limited or its affiliates. All rights reserved.
+# * Copyright 2023 NXP
 # * SPDX-License-Identifier : Apache-2.0
 # *
 # * Licensed under the Apache License, Version 2.0 (the "License");
@@ -647,6 +648,7 @@ if(${CC312_LEGACY_DRIVER_API_ENABLED})
 endif()
 
 # Build PAL NSPE LIB
+include(${PSA_ROOT_DIR}/platform/targets/common/nspe/pal_nspe.cmake)
 include(${PSA_ROOT_DIR}/platform/targets/${TARGET}/target.cmake)
 # Build VAL NSPE LIB
 #add_definitions(-DVAL_NSPE_BUILD)

--- a/api-tests/CMakeLists.txt
+++ b/api-tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 #/** @file
-# * Copyright (c) 2019-2022, Arm Limited or its affiliates. All rights reserved.
+# * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
 # * SPDX-License-Identifier : Apache-2.0
 # *
 # * Licensed under the Apache License, Version 2.0 (the "License");
@@ -122,6 +122,7 @@ list(APPEND CROSS_COMPILE_TOOLCHAIN_SUPPORT
 list(APPEND PSA_CPU_ARCH_SUPPORT
 	armv8m_ml
 	armv8m_bl
+	armv81m_ml
 	armv7m
 	armv8a
 )

--- a/api-tests/dev_apis/crypto/test_c062/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c062/test_data.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2020, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +30,7 @@ typedef struct {
 } test_data;
 
 static const test_data check1[] = {
+#ifdef ARCH_TEST_HASH_SUSPEND
 #ifdef ARCH_TEST_MD2
 {
     .test_desc         = "Test psa_hash_suspend - MD2\n",
@@ -180,5 +181,6 @@ static const test_data check1[] = {
     .operation_state   = 0,
     .expected_status   = PSA_ERROR_BAD_STATE,
 },
+#endif
 #endif
 };

--- a/api-tests/dev_apis/crypto/test_c063/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c063/test_data.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2020, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,6 +35,7 @@ typedef struct {
 } test_data;
 
 static const test_data check1[] = {
+#ifdef ARCH_TEST_HASH_RESUME
 #ifdef ARCH_TEST_MD2
 {
     .test_desc          = "Test psa_hash_resume - MD2\n",
@@ -257,5 +258,6 @@ static const test_data check1[] = {
     .operation_state    = 0,
     .expected_status    = PSA_ERROR_BAD_STATE,
 },
+#endif
 #endif
 };

--- a/api-tests/dev_apis/crypto/testsuite.db
+++ b/api-tests/dev_apis/crypto/testsuite.db
@@ -81,7 +81,7 @@ test_c058
 test_c059
 test_c060
 test_c061
-test_c062, failing_test
-test_c063, failing_test
+test_c062, skip
+test_c063, skip
 
 (END)

--- a/api-tests/docs/porting_guide_dev_apis.md
+++ b/api-tests/docs/porting_guide_dev_apis.md
@@ -66,6 +66,8 @@ Since the test suite is agnostic to various system targets, you must port the fo
 | 12 | uint32_t pal_compute_hash(int32_t cose_alg_id, struct q_useful_buf buffer_for_hash, struct q_useful_buf_c *hash, struct q_useful_buf_c protected_headers, struct q_useful_buf_c payload);                                                                | Computes hash for the requested data                       | cose_alg_id    : Algorithm ID<br/>buffer_for_hash  : Temp buffer for calculating hash<br/><br/>hash  : Pointer to store the hash<br/> buffer_for_hash  : Temp buffer for calculating hash<br/>protected_headers : data to be hashed<br/>payload  : Payload data<br/>                             |
 | 13 | uint32_t pal_crypto_pub_key_verify(int32_t cose_algorithm_id, struct q_useful_buf_c token_hash, struct q_useful_buf_c signature);                                                                | Function call to verify the signature using the public key              | cose_algorithm_id    : Algorithm ID<br/>token_hash  : Data that needs to be verified<br/>signature  : Signature to be verified against<br/>                             |
 | 14 | int pal_system_reset(void) | Resets the system | None |
+| 15 | pal_set_custom_test_list(char *custom_test_list); | Sets the custom test list buffer | custom_test_list : Custom test list buffer<br/>                             |
+| 16 | pal_is_test_enabled(test_id_t test_id); | Tells if a test is enabled on platform | test_id : Test ID<br/>                             |
 
 ## License
 Arm PSA test suite is distributed under Apache v2.0 License.

--- a/api-tests/docs/test_failure_analysis.md
+++ b/api-tests/docs/test_failure_analysis.md
@@ -10,12 +10,12 @@ The reason for each failing test is listed here in this file.
 
 | Test | Fail description                                                                | Github issue |
 |------|---------------------------------------------------------------------------------| ------------ |
-|test_c016 | This test will pass with the mbed TLS 3.1.0, TF-M 1.5.0 is not using mbed TLS 3.1.0. So the test is failing. | https://jira.arm.com/browse/PJ03206-534 |
-|test_c026 | psa_sign_message not supported | https://jira.arm.com/browse/IOTPSW-4275 |
-|test_c027 | psa_mac_update not supported | https://jira.arm.com/browse/IOTPSW-4275 |
-|test_c028 | PSA_KEY_USAGE_SIGN_MESSAGE not found | https://jira.arm.com/browse/IOTPSW-4275 |
-|test_c029 | PSA_KEY_USAGE_VERIFY_MESSAGE not supported | https://jira.arm.com/browse/IOTPSW-4275 |
-|test_c030 | PSA_KEY_USAGE_VERIFY_MESSAGE not supported | https://jira.arm.com/browse/IOTPSW-4275 |
+|test_c016 | This test will pass with the mbed TLS 3.1.0, TF-M 1.5.0 is not using mbed TLS 3.1.0. So the test is failing. |  |
+|test_c026 | psa_sign_message not supported | |
+|test_c027 | psa_mac_update not supported |  |
+|test_c028 | PSA_KEY_USAGE_SIGN_MESSAGE not found |  |
+|test_c029 | PSA_KEY_USAGE_VERIFY_MESSAGE not supported |  |
+|test_c030 | PSA_KEY_USAGE_VERIFY_MESSAGE not supported |  |
 |test_c052 | psa_aead_encrypt_setup is unimplemented in TFM/mbed-crypto. So the test has not been verified. | https://github.com/ARMmbed/mbed-crypto/issues/381 |
 |test_c053 | psa_aead_decrypt_setup is unimplemented in TFM/mbed-crypto. So the test has not been verified. | https://github.com/ARMmbed/mbed-crypto/issues/381 |
 |test_c054 | psa_aead_generate_nonce is unimplemented in TFM/mbed-crypto. So the test has not been verified. | https://github.com/ARMmbed/mbed-crypto/issues/381 |
@@ -26,8 +26,8 @@ The reason for each failing test is listed here in this file.
 |test_c059 | psa_aead_finish is unimplemented in TFM/mbed-crypto. So the test has not been verified. | https://github.com/ARMmbed/mbed-crypto/issues/381 |
 |test_c060 | psa_aead_abort is unimplemented in TFM/mbed-crypto. So the test has not been verified. | https://github.com/ARMmbed/mbed-crypto/issues/381 |
 |test_c061 | psa_aead_verify is unimplemented in TFM/mbed-crypto. So the test has not been verified. | https://github.com/ARMmbed/mbed-crypto/issues/381 |
-|test_c062 | psa_hash_suspend is unimplemented in TFM/mbed-crypto. So the test has not been verified. | https://jira.arm.com/browse/IOTPSW-4100 |
-|test_c063 | psa_hash_resume is unimplemented in TFM/mbed-crypto. So the test has not been verified. | https://jira.arm.com/browse/IOTPSW-4100 |
+|test_c062 | psa_hash_suspend is unimplemented in TFM/mbed-crypto. So the test has not been verified. |  |
+|test_c063 | psa_hash_resume is unimplemented in TFM/mbed-crypto. So the test has not been verified. |  |
 
 ## License
 
@@ -35,4 +35,4 @@ Arm PSA test suite is distributed under Apache v2.0 License.
 
 --------------
 
-*Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.*
+*Copyright (c) 2021-2023, Arm Limited and Contributors. All rights reserved.*

--- a/api-tests/platform/drivers/uart/cmsdk/pal_uart.c
+++ b/api-tests/platform/drivers/uart/cmsdk/pal_uart.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,6 +33,11 @@ void pal_uart_cmsdk_init(uint32_t uart_base_addr)
     * the minimum valid number. */
     /* Avoiding baud rate reconfiguration */
     /* ((uart_t *) g_uart)->BAUDDIV = 16; */
+}
+
+void pal_uart_cmsdk_set_baudrate(uint32_t baudrate)
+{
+    ((uart_t *) g_uart)->BAUDDIV = baudrate;
 }
 
 /**

--- a/api-tests/platform/drivers/uart/cmsdk/pal_uart.h
+++ b/api-tests/platform/drivers/uart/cmsdk/pal_uart.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -52,6 +52,7 @@ typedef struct {
 
 /* function prototypes */
 void pal_uart_cmsdk_init(uint32_t uart_base_addr);
+void pal_uart_cmsdk_set_baudrate(uint32_t baudrate);
 void pal_cmsdk_print(const char *str, int32_t data);
 void pal_uart_cmsdk_generate_irq(void);
 void pal_uart_cmsdk_disable_irq(void);

--- a/api-tests/platform/drivers/watchdog/syswatchdog/pal_wd_syswdog.c
+++ b/api-tests/platform/drivers/watchdog/syswatchdog/pal_wd_syswdog.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2020, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,9 +54,9 @@ struct wdog_frame_reg_map_t {
 #define SYSWDOG_REGISTER_BIT_WIDTH          32u
 
 /* \brief Watchdog Control and Status register bit fields */
-#define SYSWDOG_CNTR_WCS_EN_OFF    0u    /*!< Control and Status register Watchdog Enable bit field offset */
-#define SYSWDOG_CNTR_WCS_WS0_OFF   1u    /*!< Control and Status register Watchdog Signal 0 bit field offset */
-#define SYSWDOG_CNTR_WCS_WS1_OFF   2u    /*!< Control and Status register Watchdog Signal 1 bit field offset */
+#define SYSWDOG_CNTR_WCS_EN_OFF    1u    /*!< Control and Status register Watchdog Enable bit field offset */
+#define SYSWDOG_CNTR_WCS_WS0_OFF   2u    /*!< Control and Status register Watchdog Signal 0 bit field offset */
+#define SYSWDOG_CNTR_WCS_WS1_OFF   4u    /*!< Control and Status register Watchdog Signal 1 bit field offset */
 
 /**
     @brief           - Initializes an hardware watchdog timer

--- a/api-tests/platform/targets/common/nspe/pal_nspe.cmake
+++ b/api-tests/platform/targets/common/nspe/pal_nspe.cmake
@@ -1,0 +1,21 @@
+#/** @file
+# * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
+# * Copyright 2023 NXP
+# * SPDX-License-Identifier : Apache-2.0
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# *  http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+#**/
+
+# PAL C source files part of NSPE library
+list(APPEND PAL_SRC_C_NSPE
+	${PSA_ROOT_DIR}/platform/targets/common/nspe/pal_weak.c)

--- a/api-tests/platform/targets/common/nspe/pal_weak.c
+++ b/api-tests/platform/targets/common/nspe/pal_weak.c
@@ -1,0 +1,34 @@
+/** @file
+ * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright 2023 NXP
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#include "pal_common.h"
+
+__attribute__((weak)) void pal_set_custom_test_list(char *custom_test_list)
+{
+	(void)custom_test_list;
+
+	return;
+}
+
+__attribute__((weak)) bool_t pal_is_test_enabled(test_id_t test_id)
+{
+	(void)test_id;
+
+	return 1;
+}
+

--- a/api-tests/platform/targets/tgt_dev_apis_linux/nspe/pal_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_linux/nspe/pal_config.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -59,8 +59,10 @@ typedef uint32_t            cfg_id_t;
 /* Version of crypto spec used in attestation */
 #define CRYPTO_VERSION_BETA3
 
+#ifndef PLATFORM_HAS_ATTEST_PK
 /* Use hardcoded public key */
 #define PLATFORM_OVERRIDE_ATTEST_PK
+#endif
 
 /*
  * Include of PSA defined Header files

--- a/api-tests/platform/targets/tgt_dev_apis_linux/nspe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_linux/nspe/pal_driver_intf.c
@@ -1,5 +1,6 @@
 /** @file
  * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright 2023 NXP
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,6 +38,15 @@
 
 #define NVMEM_SIZE (1024)
 static uint8_t g_nvmem[NVMEM_SIZE];
+
+/* The custom test list is a buffer in which all enabled test names are concatenated.
+ * The test name template is <TEST_NAME_PREFIX><id><TEST_NAME_SUFFIX>, where <id>
+ * is the test identifier.
+ */
+#define TEST_NAME_PREFIX "test_"
+#define TEST_NAME_SUFFIX ";"
+
+char *g_custom_test_list = NULL;
 
 /**
     @brief    - Check that an nvmem access is within the bounds of the nvmem
@@ -197,4 +207,32 @@ void pal_terminate_simulation(void)
 int pal_system_reset(void)
 {
     return PAL_STATUS_UNSUPPORTED_FUNC;
+}
+
+/**
+ *   @brief    - Sets the custom test list buffer
+ *   @param    - custom_test_list : Custom test list buffer 
+     @return   - void
+**/
+void pal_set_custom_test_list(char *custom_test_list)
+{
+    g_custom_test_list = custom_test_list;
+}
+
+/**
+ *   @brief    - Tells if a test is enabled on platform
+ *   @param    - test_id : Test ID
+ *   @return   - TRUE/FALSE
+**/
+bool_t pal_is_test_enabled(test_id_t test_id)
+{
+    char test_id_str[16] = { 0 };
+
+    if (!g_custom_test_list)
+        return 1;
+
+    if (sprintf(test_id_str, "%s%d%s", TEST_NAME_PREFIX, test_id, TEST_NAME_SUFFIX) <= 0)
+        return 0;
+
+    return strstr(g_custom_test_list, test_id_str)?1:0;
 }

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an521/nspe/pal_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an521/nspe/pal_config.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019-2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,8 +47,10 @@
 /* Version of crypto spec used in attestation */
 #define CRYPTO_VERSION_BETA3
 
+#ifndef PLATFORM_HAS_ATTEST_PK
 /* Use hardcoded public key */
 #define PLATFORM_OVERRIDE_ATTEST_PK
+#endif
 
 /*
  * Include of PSA defined Header files

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an521/nspe/pal_crypto_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an521/nspe/pal_crypto_config.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019-2022, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -384,6 +384,21 @@
  * Enable ECC support for asymmetric API.
 */
 //#define ARCH_TEST_ECC_ASYMMETRIC_API_SUPPORT
+
+/**
+ * \def ARCH_TEST_HASH_SUSPEND
+ *
+ * Enable has suspend.
+*/
+//#define ARCH_TEST_HASH_SUSPEND
+
+/**
+ * \def ARCH_TEST_HASH_RESUME
+ *
+ * Enable has resume.
+*/
+//#define ARCH_TEST_HASH_RESUME
+
 #include "pal_crypto_config_check.h"
 
 #endif /* _PAL_CRYPTO_CONFIG_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_cs3x0/nspe/pal_attestation_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_cs3x0/nspe/pal_attestation_config.h
@@ -1,0 +1,107 @@
+/** @file
+ * Copyright (c) 2020-2023, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef _PAL_ATTESTATION_CONFIG_H_
+#define _PAL_ATTESTATION_CONFIG_H_
+
+#define COSE_ALGORITHM_ES256             -7
+#define COSE_ALG_SHA256_PROPRIETARY      -72000
+
+#define USEFUL_BUF_MAKE_STACK_UB UsefulBuf_MAKE_STACK_UB
+
+#define COSE_SIG_CONTEXT_STRING_SIGNATURE1 "Signature1"
+
+/* Private value. Intentionally not documented for Doxygen.
+ * This is the size allocated for the encoded protected headers.  It
+ * needs to be big enough for make_protected_header() to succeed. It
+ * currently sized for one header with an algorithm ID up to 32 bits
+ * long -- one byte for the wrapping map, one byte for the label, 5
+ * bytes for the ID. If this is made accidentially too small, QCBOR will
+ * only return an error, and not overrun any buffers.
+ *
+ * 9 extra bytes are added, rounding it up to 16 total, in case some
+ * other protected header is to be added.
+ */
+#define T_COSE_SIGN1_MAX_PROT_HEADER (1+1+5+9)
+
+/**
+ * This is the size of the first part of the CBOR encoded TBS
+ * bytes. It is around 20 bytes. See create_tbs_hash().
+ */
+#define T_COSE_SIZE_OF_TBS \
+    1 + /* For opening the array */ \
+    sizeof(COSE_SIG_CONTEXT_STRING_SIGNATURE1) + /* "Signature1" */ \
+    2 + /* Overhead for encoding string */ \
+    T_COSE_SIGN1_MAX_PROT_HEADER + /* entire protected headers */ \
+    3 * (/* 3 NULL bstrs for fields not used */ \
+        1 /* size of a NULL bstr */  \
+    )
+#define NULL_USEFUL_BUF_C  NULLUsefulBufC
+
+#define ATTEST_PUBLIC_KEY_SLOT                  4
+#define ECC_CURVE_SECP256R1_PULBIC_KEY_LENGTH   (1 + 2 * PSA_BITS_TO_BYTES(256))
+
+typedef struct {
+    uint8_t  *pubx_key;
+    size_t    pubx_key_size;
+    uint8_t  *puby_key;
+    size_t    puby_key_size;
+} ecc_key_t;
+
+struct ecc_public_key_t {
+    const uint8_t a;
+    uint8_t public_key[]; /* X-coordinate || Y-coordinate */
+};
+
+static const struct ecc_public_key_t attest_public_key = {
+     /* Constant byte */
+     0x04,
+     /* X-coordinate */
+     {0x79, 0xEB, 0xA9, 0x0E, 0x8B, 0xF4, 0x50, 0xA6,
+      0x75, 0x15, 0x76, 0xAD, 0x45, 0x99, 0xB0, 0x7A,
+      0xDF, 0x93, 0x8D, 0xA3, 0xBB, 0x0B, 0xD1, 0x7D,
+      0x00, 0x36, 0xED, 0x49, 0xA2, 0xD0, 0xFC, 0x3F,
+     /* Y-coordinate */
+      0xBF, 0xCD, 0xFA, 0x89, 0x56, 0xB5, 0x68, 0xBF,
+      0xDB, 0x86, 0x73, 0xE6, 0x48, 0xD8, 0xB5, 0x8D,
+      0x92, 0x99, 0x55, 0xB1, 0x4A, 0x26, 0xC3, 0x08,
+      0x0F, 0x34, 0x11, 0x7D, 0x97, 0x1D, 0x68, 0x64},
+};
+
+static const uint8_t initial_attestation_public_x_key[] = {
+    0x79, 0xEB, 0xA9, 0x0E, 0x8B, 0xF4, 0x50, 0xA6,
+    0x75, 0x15, 0x76, 0xAD, 0x45, 0x99, 0xB0, 0x7A,
+    0xDF, 0x93, 0x8D, 0xA3, 0xBB, 0x0B, 0xD1, 0x7D,
+    0x00, 0x36, 0xED, 0x49, 0xA2, 0xD0, 0xFC, 0x3F
+};
+
+static const uint8_t initial_attestation_public_y_key[] = {
+    0xBF, 0xCD, 0xFA, 0x89, 0x56, 0xB5, 0x68, 0xBF,
+    0xDB, 0x86, 0x73, 0xE6, 0x48, 0xD8, 0xB5, 0x8D,
+    0x92, 0x99, 0x55, 0xB1, 0x4A, 0x26, 0xC3, 0x08,
+    0x0F, 0x34, 0x11, 0x7D, 0x97, 0x1D, 0x68, 0x64
+};
+
+/* Initialize the structure with given public key */
+static const ecc_key_t attest_key = {
+        (uint8_t *)initial_attestation_public_x_key,
+        sizeof(initial_attestation_public_x_key),
+        (uint8_t *)initial_attestation_public_y_key,
+        sizeof(initial_attestation_public_y_key)
+};
+
+#endif /* _PAL_ATTESTATION_CONFIG_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_cs3x0/nspe/pal_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_cs3x0/nspe/pal_config.h
@@ -1,0 +1,95 @@
+/** @file
+ * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef _PAL_CONFIG_H_
+#define _PAL_CONFIG_H_
+
+#include "pal_crypto_config.h"
+#include "pal_attestation_config.h"
+#include "pal_storage_config.h"
+
+/* Define PSA test suite dependent macros for non-cmake build */
+#if !defined(PSA_CMAKE_BUILD)
+
+/* Print verbosity = TEST */
+#define VERBOSE 3
+
+/* NSPE or SPE VAL build? */
+#define VAL_NSPE_BUILD
+
+/* NSPE or SPE TEST build? */
+#define NONSECURE_TEST_BUILD
+
+/* If not defined, skip watchdog programming */
+#define WATCHDOG_AVAILABLE
+
+/* Are Dynamic memory APIs available to secure partition? */
+#define SP_HEAP_MEM_SUPP
+
+/* PSA Isolation level supported by platform */
+#define PLATFORM_PSA_ISOLATION_LEVEL 3
+#endif /* PSA_CMAKE_BUILD */
+
+/* Version of crypto spec used in attestation */
+#define CRYPTO_VERSION_BETA3
+
+/* Use hardcoded public key */
+#define PLATFORM_OVERRIDE_ATTEST_PK
+
+/*
+ * Include of PSA defined Header files
+ */
+#ifdef IPC
+/* psa/client.h: Contains the PSA Client API elements */
+#include "psa/client.h"
+
+/*
+ * psa_manifest/sid.h:  Macro definitions derived from manifest files that map from RoT Service
+ * names to Service IDs (SIDs). Partition manifest parse build tool must provide the implementation
+ * of this file.
+*/
+#include "psa_manifest/sid.h"
+
+/*
+ * psa_manifest/pid.h: Secure Partition IDs
+ * Macro definitions that map from Secure Partition names to Secure Partition IDs.
+ * Partition manifest parse build tool must provide the implementation of this file.
+*/
+#include "psa_manifest/pid.h"
+#endif
+
+#ifdef CRYPTO
+/* psa/crypto.h: Contains the PSA Crypto API elements */
+#include "psa/crypto.h"
+#endif
+
+#if defined(INTERNAL_TRUSTED_STORAGE) || defined(STORAGE)
+/* psa/internal_trusted_storage.h: Contains the PSA ITS API elements */
+#include "psa/internal_trusted_storage.h"
+#endif
+
+#if defined(PROTECTED_STORAGE) || defined(STORAGE)
+/* psa/protected_storage.h: Contains the PSA PS API elements */
+#include "psa/protected_storage.h"
+#endif
+
+#ifdef INITIAL_ATTESTATION
+/* psa/initial_attestation.h: Contains the PSA Initial Attestation API elements */
+#include "psa/initial_attestation.h"
+#endif
+
+#endif /* _PAL_CONFIG_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_cs3x0/nspe/pal_crypto_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_cs3x0/nspe/pal_crypto_config.h
@@ -1,0 +1,389 @@
+/** @file
+ * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+/*
+ * \file pal_crypto_config.h
+ *
+ * \brief Configuration options for crypto tests (set of defines)
+ *
+ *  This set of compile-time options may be used to enable
+ *  or disable features selectively for crypto test suite
+ */
+
+#ifndef _PAL_CRYPTO_CONFIG_H_
+#define _PAL_CRYPTO_CONFIG_H_
+/**
+ * \def ARCH_TEST_RSA
+ *
+ * Enable the RSA public-key cryptosystem.
+ * By default all supported keys are enabled.
+ *
+ * Comment macros to disable the types
+ */
+#ifndef TF_M_PROFILE_SMALL
+#ifndef TF_M_PROFILE_MEDIUM
+#define ARCH_TEST_RSA
+#define ARCH_TEST_RSA_1024
+#define ARCH_TEST_RSA_2048
+#define ARCH_TEST_RSA_3072
+#endif
+#endif
+
+/**
+ * \def  ARCH_TEST_ECC
+ * \def  ARCH_TEST_ECC_CURVE_SECPXXXR1
+ *
+ * Enable the elliptic curve
+ * Enable specific curves within the Elliptic Curve
+ * module.  By default all supported curves are enabled.
+ *
+ * Requires: ARCH_TEST_ECC
+ * Comment macros to disable the curve
+ */
+#ifndef TF_M_PROFILE_SMALL
+#define ARCH_TEST_ECC
+#define ARCH_TEST_ECC_CURVE_SECP192R1
+#ifndef TF_M_PROFILE_MEDIUM
+#define ARCH_TEST_ECC_CURVE_SECP224R1
+#endif
+#define ARCH_TEST_ECC_CURVE_SECP256R1
+#ifndef TF_M_PROFILE_MEDIUM
+#define ARCH_TEST_ECC_CURVE_SECP384R1
+#endif
+#endif
+/* curves of size <255 are obsolete algorithms, should be disabled. */
+#undef ARCH_TEST_ECC_CURVE_SECP192R1
+#undef ARCH_TEST_ECC_CURVE_SECP224R1
+
+/**
+ * \def ARCH_TEST_AES
+ *
+ * Enable the AES block cipher.
+ * By default all supported keys are enabled.
+ *
+ * Comment macros to disable the types
+ */
+#define ARCH_TEST_AES
+#define ARCH_TEST_AES_128
+#define ARCH_TEST_AES_192
+#define ARCH_TEST_AES_256
+#define ARCH_TEST_AES_512
+
+/**
+ * \def  ARCH_TEST_DES
+ *
+ * Enable the DES block cipher.
+ * By default all supported keys are enabled.
+ *
+ * Comment macros to disable the types
+ */
+//#define ARCH_TEST_DES
+//#define ARCH_TEST_DES_1KEY
+//#define ARCH_TEST_DES_2KEY
+//#define ARCH_TEST_DES_3KEY
+
+/**
+ * \def  ARCH_TEST_RAW
+ *
+ * A "key" of this type cannot be used for any cryptographic operation.
+ * Applications may use this type to store arbitrary data in the keystore.
+ */
+#define ARCH_TEST_RAW
+
+/**
+ * \def ARCH_TEST_CIPHER
+ *
+ * Enable the generic cipher layer.
+ */
+
+#define ARCH_TEST_CIPHER
+
+/**
+ * \def ARCH_TEST_ARC4
+ *
+ * Enable the ARC4 key type.
+ */
+//#define ARCH_TEST_ARC4
+
+/**
+ * \def ARCH_TEST_CIPHER_MODE_CTR
+ *
+ * Enable Counter Block Cipher mode (CTR) for symmetric ciphers.
+ *
+ * Requires: ARCH_TEST_CIPHER
+ */
+#ifndef TF_M_PROFILE_SMALL
+#ifndef TF_M_PROFILE_MEDIUM
+#define ARCH_TEST_CIPHER_MODE_CTR
+#endif
+#endif
+
+/**
+ * \def ARCH_TEST_CIPHER_MODE_CFB
+ *
+ * Enable Cipher Feedback mode (CFB) for symmetric ciphers.
+ *
+ * Requires: ARCH_TEST_CIPHER
+ */
+#define ARCH_TEST_CIPHER_MODE_CFB
+
+/**
+ * \def ARCH_TEST_CIPHER_MODE_CBC
+ *
+ * Enable Cipher Block Chaining mode (CBC) for symmetric ciphers.
+ *
+ * Requires: ARCH_TEST_CIPHER
+ */
+#define ARCH_TEST_CIPHER_MODE_CBC
+
+/**
+ * \def ARCH_TEST_CTR_AES
+ *
+ * Requires: ARCH_TEST_CIPHER, ARCH_TEST_AES, ARCH_TEST_CIPHER_MODE_CTR
+ */
+#ifndef TF_M_PROFILE_SMALL
+#ifndef TF_M_PROFILE_MEDIUM
+#define ARCH_TEST_CTR_AES
+#endif
+#endif
+
+/**
+ * \def ARCH_TEST_CBC_AES
+ *
+ * Requires: ARCH_TEST_CIPHER, ARCH_TEST_AES, ARCH_TEST_CIPHER_MODE_CBC
+ *
+ * Comment macros to disable the types
+ */
+#define ARCH_TEST_CBC_AES
+#define ARCH_TEST_CBC_AES_NO_PADDING
+
+/**
+ * \def ARCH_TEST_CBC_NO_PADDING
+ *
+ * Requires: ARCH_TEST_CIPHER, ARCH_TEST_CIPHER_MODE_CBC
+ *
+ * Comment macros to disable the types
+ */
+#ifndef TF_M_PROFILE_SMALL
+#ifndef TF_M_PROFILE_MEDIUM
+#define ARCH_TEST_CBC_NO_PADDING
+#endif
+#endif
+
+/**
+ * \def ARCH_TEST_CFB_AES
+ *
+ * Requires: ARCH_TEST_CIPHER, ARCH_TEST_AES, ARCH_TEST_CIPHER_MODE_CFB
+ */
+#define ARCH_TEST_CFB_AES
+
+/**
+ * \def ARCH_TEST_PKCS1V15_*
+ *
+ * Enable support for PKCS#1 v1.5 encoding.
+ * Enable support for PKCS#1 v1.5 operations.
+ * Enable support for RSA-OAEP
+ *
+ * Requires: ARCH_TEST_RSA, ARCH_TEST_PKCS1V15
+ *
+ * Comment macros to disable the types
+ */
+#ifndef TF_M_PROFILE_SMALL
+#ifndef TF_M_PROFILE_MEDIUM
+#define ARCH_TEST_PKCS1V15
+#define ARCH_TEST_RSA_PKCS1V15_SIGN
+#define ARCH_TEST_RSA_PKCS1V15_SIGN_RAW
+#define ARCH_TEST_RSA_PKCS1V15_CRYPT
+#define ARCH_TEST_RSA_OAEP
+#endif
+#endif
+
+/**
+ * \def ARCH_TEST_CBC_PKCS7
+ *
+ * Requires: ARCH_TEST_CIPHER_MODE_CBC
+ *
+ * Comment macros to disable the types
+ */
+#ifndef TF_M_PROFILE_SMALL
+#ifndef TF_M_PROFILE_MEDIUM
+#define ARCH_TEST_CBC_PKCS7
+#endif
+#endif
+
+/**
+ * \def ARCH_TEST_ASYMMETRIC_ENCRYPTION
+ *
+ * Enable support for Asymmetric encryption algorithms
+ */
+#define ARCH_TEST_ASYMMETRIC_ENCRYPTION
+
+/**
+ * \def ARCH_TEST_HASH
+ *
+ * Enable the hash algorithm.
+ */
+#define ARCH_TEST_HASH
+
+/**
+ * \def  ARCH_TEST_HMAC
+ *
+ * The key policy determines which underlying hash algorithm the key can be
+ * used for.
+ *
+ * Requires: ARCH_TEST_HASH
+ */
+#define ARCH_TEST_HMAC
+
+/**
+ * \def ARCH_TEST_MDX
+ * \def ARCH_TEST_SHAXXX
+ *
+ * Enable the MDX algorithm.
+ * Enable the SHAXXX algorithm.
+ *
+ * Requires: ARCH_TEST_HASH
+ *
+ * Comment macros to disable the types
+ */
+//#define ARCH_TEST_MD2
+//#define ARCH_TEST_MD4
+//#define ARCH_TEST_MD5
+//#define ARCH_TEST_RIPEMD160
+//#define ARCH_TEST_SHA1
+#ifndef TF_M_PROFILE_SMALL
+#define ARCH_TEST_SHA224
+#endif
+#define ARCH_TEST_SHA256
+#ifndef TF_M_PROFILE_SMALL
+#ifndef TF_M_PROFILE_MEDIUM
+#define ARCH_TEST_SHA384
+#define ARCH_TEST_SHA512
+#endif
+#endif
+//#define ARCH_TEST_SHA512_224
+//#define ARCH_TEST_SHA512_256
+//#define ARCH_TEST_SHA3_224
+//#define ARCH_TEST_SHA3_256
+//#define ARCH_TEST_SHA3_384
+//#define ARCH_TEST_SHA3_512
+
+/**
+ * \def ARCH_TEST_HKDF
+ *
+ * Enable the HKDF algorithm (RFC 5869).
+ *
+ * Requires: ARCH_TEST_HASH
+*/
+#define ARCH_TEST_HKDF
+
+/**
+ * \def ARCH_TEST_TLS12_PRF
+ *
+ * Enable the TLS-1.2 PRF algorithm (RFC 5246).
+ *
+ * Requires: ARCH_TEST_HASH
+*/
+#define ARCH_TEST_TLS12_PRF
+
+/**
+ * \def ARCH_TEST_xMAC
+ *
+ * Enable the xMAC (Cipher/Hash/G-based Message Authentication Code) mode for block
+ * ciphers.
+ * Requires: ARCH_TEST_AES or ARCH_TEST_DES
+ *
+ * Comment macros to disable the types
+ */
+#ifndef TF_M_PROFILE_SMALL
+#ifndef TF_M_PROFILE_MEDIUM
+#define ARCH_TEST_CMAC
+#endif
+#endif
+//#define ARCH_TEST_GMAC
+#define ARCH_TEST_HMAC
+
+/**
+ * \def ARCH_TEST_CCM
+ *
+ * Enable the Counter with CBC-MAC (CCM) mode for 128-bit block cipher.
+ *
+ * Requires: ARCH_TEST_AES
+ */
+#define ARCH_TEST_CCM
+
+/**
+ * \def ARCH_TEST_GCM
+ *
+ * Enable the Galois/Counter Mode (GCM) for AES.
+ *
+ * Requires: ARCH_TEST_AES
+ *
+ */
+#ifndef TF_M_PROFILE_SMALL
+#ifndef TF_M_PROFILE_MEDIUM
+#define ARCH_TEST_GCM
+#endif
+#endif
+
+/**
+ * \def ARCH_TEST_TRUNCATED_MAC
+ *
+ * Enable support for RFC 6066 truncated HMAC in SSL.
+ *
+ * Comment this macro to disable support for truncated HMAC in SSL
+ */
+#define ARCH_TEST_TRUNCATED_MAC
+
+
+/**
+ * \def ARCH_TEST_ECDH
+ *
+ * Enable the elliptic curve Diffie-Hellman library.
+ *
+ * Requires: ARCH_TEST_ECC
+ */
+#ifndef TF_M_PROFILE_SMALL
+#define ARCH_TEST_ECDH
+#endif
+
+/**
+ * \def ARCH_TEST_ECDSA
+ *
+ * Enable the elliptic curve DSA library.
+ * Requires: ARCH_TEST_ECC
+ */
+#ifndef TF_M_PROFILE_SMALL
+#define ARCH_TEST_ECDSA
+#endif
+
+/**
+ * \def ARCH_TEST_DETERMINISTIC_ECDSA
+ *
+ * Enable deterministic ECDSA (RFC 6979).
+*/
+#define ARCH_TEST_DETERMINISTIC_ECDSA
+
+/**
+ * \def ARCH_TEST_ECC_ASYMMETRIC_API_SUPPORT
+ *
+ * Enable ECC support for asymmetric API.
+*/
+//#define ARCH_TEST_ECC_ASYMMETRIC_API_SUPPORT
+#include "pal_crypto_config_check.h"
+
+#endif /* _PAL_CRYPTO_CONFIG_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_cs3x0/nspe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_cs3x0/nspe/pal_driver_intf.c
@@ -1,0 +1,144 @@
+/** @file
+ * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#include "pal_common.h"
+#include "pal_uart.h"
+#include "pal_nvmem.h"
+#include "pal_wd_syswdog.h"
+
+/**
+    @brief    - This function initializes the UART
+    @param    - uart base addr
+    @return   - SUCCESS/FAILURE
+**/
+int pal_uart_init_ns(uint32_t uart_base_addr)
+{
+    pal_uart_cmsdk_init(uart_base_addr);
+    return PAL_STATUS_SUCCESS;
+}
+
+/**
+    @brief    - This function parses the input string and writes bytes into UART TX FIFO
+    @param    - str      : Input String
+              - data     : Value for format specifier
+    @return   - SUCCESS/FAILURE
+**/
+
+int pal_print_ns(const char *str, int32_t data)
+{
+    pal_cmsdk_print(str, data);
+    return PAL_STATUS_SUCCESS;
+}
+
+/**
+    @brief           - Initializes an hardware watchdog timer
+    @param           - base_addr       : Base address of the watchdog module
+                     - time_us         : Time in micro seconds
+                     - timer_tick_us   : Number of ticks per micro second
+    @return          - SUCCESS/FAILURE
+**/
+int pal_wd_timer_init_ns(addr_t base_addr, uint32_t time_us, uint32_t timer_tick_us)
+{
+    return(pal_wd_syswdog_init(base_addr,time_us, timer_tick_us));
+}
+
+/**
+    @brief           - Enables a hardware watchdog timer
+    @param           - base_addr       : Base address of the watchdog module
+    @return          - SUCCESS/FAILURE
+**/
+int pal_wd_timer_enable_ns(addr_t base_addr)
+{
+    return(pal_wd_syswdog_enable(base_addr));
+}
+
+/**
+    @brief           - Disables a hardware watchdog timer
+    @param           - base_addr  : Base address of the watchdog module
+    @return          - SUCCESS/FAILURE
+**/
+int pal_wd_timer_disable_ns(addr_t base_addr)
+{
+    return (pal_wd_syswdog_disable(base_addr));
+}
+
+/**
+    @brief    - Reads from given non-volatile address.
+    @param    - base    : Base address of nvmem
+                offset  : Offset
+                buffer  : Pointer to source address
+                size    : Number of bytes
+    @return   - SUCCESS/FAILURE
+**/
+int pal_nvmem_read_ns(addr_t base, uint32_t offset, void *buffer, int size)
+{
+    if (nvmem_read(base, offset, buffer, size))
+    {
+        return PAL_STATUS_SUCCESS;
+    }
+    else
+    {
+        return PAL_STATUS_ERROR;
+    }
+}
+
+/**
+    @brief    - Writes into given non-volatile address.
+    @param    - base    : Base address of nvmem
+                offset  : Offset
+                buffer  : Pointer to source address
+                size    : Number of bytes
+    @return   - SUCCESS/FAILURE
+**/
+int pal_nvmem_write_ns(addr_t base, uint32_t offset, void *buffer, int size)
+{
+    if (nvmem_write(base, offset, buffer, size))
+    {
+        return PAL_STATUS_SUCCESS;
+    }
+    else
+    {
+        return PAL_STATUS_ERROR;
+    }
+}
+
+/**
+ *   @brief    - Terminates the simulation at the end of all tests completion.
+ *               By default, it put cpus into power down mode.
+ *   @param    - void
+ *   @return   - void
+**/
+void pal_terminate_simulation(void)
+{
+    /* Add logic to terminate the simluation */
+
+    while(1)
+    {
+        __asm volatile("WFI");
+    }
+}
+
+/**
+ *   @brief    - Resets the system.
+ *   @param    - void
+ *   @return   - SUCCESS/FAILURE
+**/
+int pal_system_reset(void)
+{
+    /* Reset functionality is not functional on AN521 FVP */
+    return PAL_STATUS_UNSUPPORTED_FUNC;
+}

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_cs3x0/nspe/pal_storage_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_cs3x0/nspe/pal_storage_config.h
@@ -1,0 +1,24 @@
+/** @file
+ * Copyright (c) 2020-2023, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef _PAL_STORAGE_CONFIG_H_
+#define _PAL_STORAGE_CONFIG_H_
+
+/* Platform specific max UID's size */
+#define ARCH_TEST_STORAGE_UID_MAX_SIZE 512
+
+#endif /* _PAL_STORAGE_CONFIG_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_cs3x0/target.cfg
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_cs3x0/target.cfg
@@ -1,0 +1,41 @@
+///** @file
+// * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
+// * SPDX-License-Identifier : Apache-2.0
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *  http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+//**/
+
+// UART device info
+uart.num=1;
+uart.0.base = 0x49303000; // UART0_NS
+uart.0.size = 0xFFF;
+uart.0.intr_id = 0xFF;
+uart.0.permission = TYPE_READ_WRITE;
+
+// Watchdog device info
+watchdog.num = 1;
+watchdog.0.base = 0x48040000;
+watchdog.0.size = 0x2000;
+watchdog.0.intr_id = 0xFF;
+watchdog.0.permission = TYPE_READ_WRITE;
+watchdog.0.num_of_tick_per_micro_sec = 0x19;         //(sys_feq/1000000)
+watchdog.0.timeout_in_micro_sec_low = 0xF4240;      //1.0  sec :  1 * 1000 * 1000
+watchdog.0.timeout_in_micro_sec_medium = 0x1E8480;  //2.0  sec :  2 * 1000 * 1000
+watchdog.0.timeout_in_micro_sec_high = 0x4C4B40;    //5.0  sec :  5 * 1000 * 1000
+watchdog.0.timeout_in_micro_sec_crypto = 0x1312D00; //18.0 sec : 18 * 1000 * 1000
+
+// Range of 1KB Non-volatile memory to preserve data over reset. Ex, NVRAM and FLASH
+nvmem.num =1;
+nvmem.0.start = 0x010BFC00;
+nvmem.0.end = 0x010BFFFF;
+nvmem.0.permission = TYPE_READ_WRITE;

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_cs3x0/target.cmake
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_cs3x0/target.cmake
@@ -1,0 +1,97 @@
+#/** @file
+# * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
+# * SPDX-License-Identifier : Apache-2.0
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# *  http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+#**/
+
+# PAL C source files part of NSPE library
+list(APPEND PAL_SRC_C_NSPE )
+
+# PAL ASM source files part of NSPE library
+list(APPEND PAL_SRC_ASM_NSPE )
+
+# PAL C source files part of SPE library - driver partition
+list(APPEND PAL_SRC_C_DRIVER_SP )
+
+# PAL ASM source files part of SPE library - driver partition
+list(APPEND PAL_SRC_ASM_DRIVER_SP )
+
+# Listing all the sources required for given target
+if(${SUITE} STREQUAL "IPC")
+    message(FATAL_ERROR "For IPC - use -DTARGET=tgt_ff_tfm_cs3x0 instead")
+else()
+    list(APPEND PAL_SRC_C_NSPE
+        # driver files will be compiled as part of NSPE
+        ${PSA_ROOT_DIR}/platform/targets/${TARGET}/nspe/pal_driver_intf.c
+        ${PSA_ROOT_DIR}/platform/drivers/nvmem/pal_nvmem.c
+        ${PSA_ROOT_DIR}/platform/drivers/uart/cmsdk/pal_uart.c
+        ${PSA_ROOT_DIR}/platform/drivers/watchdog/syswatchdog/pal_wd_syswdog.c
+    )
+endif()
+
+if(${SUITE} STREQUAL "CRYPTO")
+    list(APPEND PAL_SRC_C_NSPE
+        ${PSA_ROOT_DIR}/platform/targets/common/nspe/crypto/pal_crypto_intf.c
+    )
+endif()
+if((${SUITE} STREQUAL "PROTECTED_STORAGE") OR (${SUITE} STREQUAL "STORAGE"))
+    list(APPEND PAL_SRC_C_NSPE
+        ${PSA_ROOT_DIR}/platform/targets/common/nspe/protected_storage/pal_protected_storage_intf.c
+    )
+endif()
+if((${SUITE} STREQUAL "INTERNAL_TRUSTED_STORAGE") OR (${SUITE} STREQUAL "STORAGE"))
+    list(APPEND PAL_SRC_C_NSPE
+        ${PSA_ROOT_DIR}/platform/targets/common/nspe/internal_trusted_storage/pal_internal_trusted_storage_intf.c
+    )
+endif()
+if(${SUITE} STREQUAL "INITIAL_ATTESTATION")
+    list(APPEND PAL_SRC_C_NSPE
+        ${PSA_ROOT_DIR}/platform/targets/common/nspe/initial_attestation/pal_attestation_intf.c
+        ${PSA_ROOT_DIR}/platform/targets/common/nspe/initial_attestation/pal_attestation_crypto.c
+        ${PSA_TARGET_QCBOR}/src/UsefulBuf.c
+        ${PSA_TARGET_QCBOR}/src/ieee754.c
+        ${PSA_TARGET_QCBOR}/src/qcbor_decode.c
+        ${PSA_TARGET_QCBOR}/src/qcbor_encode.c
+    )
+endif()
+
+# Create NSPE library
+add_library(${PSA_TARGET_PAL_NSPE_LIB} STATIC ${PAL_SRC_C_NSPE} ${PAL_SRC_ASM_NSPE})
+
+# PSA Include directories
+foreach(psa_inc_path ${PSA_INCLUDE_PATHS})
+    target_include_directories(${PSA_TARGET_PAL_NSPE_LIB} PRIVATE ${psa_inc_path})
+endforeach()
+
+list(APPEND PAL_DRIVER_INCLUDE_PATHS
+    ${PSA_ROOT_DIR}/platform/drivers/nvmem
+    ${PSA_ROOT_DIR}/platform/drivers/uart/cmsdk
+    ${PSA_ROOT_DIR}/platform/drivers/watchdog/syswatchdog
+)
+
+target_include_directories(${PSA_TARGET_PAL_NSPE_LIB} PRIVATE
+    ${PAL_DRIVER_INCLUDE_PATHS}
+    ${PSA_ROOT_DIR}/platform/targets/common/nspe
+    ${PSA_ROOT_DIR}/platform/targets/common/nspe/crypto
+    ${PSA_ROOT_DIR}/platform/targets/common/nspe/protected_storage
+    ${PSA_ROOT_DIR}/platform/targets/common/nspe/internal_trusted_storage
+    ${PSA_ROOT_DIR}/platform/targets/common/nspe/initial_attestation
+    ${PSA_ROOT_DIR}/platform/targets/${TARGET}/nspe
+)
+
+if(${SUITE} STREQUAL "INITIAL_ATTESTATION")
+target_include_directories(${PSA_TARGET_PAL_NSPE_LIB} PRIVATE
+    ${PSA_QCBOR_INCLUDE_PATH}
+)
+endif()

--- a/api-tests/platform/targets/tgt_ff_tfm_cs3x0/nspe/pal_config.h
+++ b/api-tests/platform/targets/tgt_ff_tfm_cs3x0/nspe/pal_config.h
@@ -1,0 +1,71 @@
+/** @file
+ * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef _PAL_CONFIG_H_
+#define _PAL_CONFIG_H_
+
+/* Define PSA test suite dependent macros for non-cmake build */
+#if !defined(PSA_CMAKE_BUILD)
+
+/* Print verbosity = TEST */
+#define VERBOSE 3
+
+/* NSPE or SPE VAL build? */
+#define VAL_NSPE_BUILD
+
+/* NSPE or SPE TEST build? */
+#define NONSECURE_TEST_BUILD
+
+/* If not defined, skip watchdog programming */
+#define WATCHDOG_AVAILABLE
+
+/* Are Dynamic memory APIs available to secure partition? */
+#define SP_HEAP_MEM_SUPP
+
+/* PSA Isolation level supported by platform */
+#define PLATFORM_PSA_ISOLATION_LEVEL 3
+#endif /* PSA_CMAKE_BUILD */
+
+/* Version of crypto spec used in attestation */
+#define CRYPTO_VERSION_BETA3
+
+/* Use hardcoded public key */
+#define PLATFORM_OVERRIDE_ATTEST_PK
+
+/*
+ * Include of PSA defined Header files
+ */
+#ifdef IPC
+/* psa/client.h: Contains the PSA Client API elements */
+#include "psa/client.h"
+
+/*
+ * psa_manifest/sid.h:  Macro definitions derived from manifest files that map from RoT Service
+ * names to Service IDs (SIDs). Partition manifest parse build tool must provide the implementation
+ * of this file.
+*/
+#include "psa_manifest/sid.h"
+
+/*
+ * psa_manifest/pid.h: Secure Partition IDs
+ * Macro definitions that map from Secure Partition names to Secure Partition IDs.
+ * Partition manifest parse build tool must provide the implementation of this file.
+*/
+#include "psa_manifest/pid.h"
+#endif
+
+#endif /* _PAL_CONFIG_H_ */

--- a/api-tests/platform/targets/tgt_ff_tfm_cs3x0/nspe/pal_driver_ipc_intf.c
+++ b/api-tests/platform/targets/tgt_ff_tfm_cs3x0/nspe/pal_driver_ipc_intf.c
@@ -1,0 +1,338 @@
+/** @file
+ * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#include "pal_common.h"
+
+/**
+    @brief    - This function initializes the UART
+    @param    - uart base addr
+    @return   - SUCCESS/FAILURE
+**/
+int pal_uart_init_ns(uint32_t uart_base_addr)
+{
+    psa_status_t            status_of_call = PSA_SUCCESS;
+    uart_fn_type_t          uart_fn = UART_INIT;
+
+    psa_invec data[3] = {{&uart_fn, sizeof(uart_fn)},
+                         {&uart_base_addr, sizeof(uart_base_addr)},
+                         {NULL, 0}};
+
+#if STATELESS_ROT == 1
+    status_of_call = psa_call(DRIVER_UART_HANDLE, 0, data, 3, NULL, 0);
+    if (status_of_call != PSA_SUCCESS)
+        return PAL_STATUS_ERROR;
+
+    return PAL_STATUS_SUCCESS;
+#else
+    psa_handle_t            print_handle = 0;
+    print_handle = psa_connect(DRIVER_UART_SID, DRIVER_UART_VERSION);
+    if (PSA_HANDLE_IS_VALID(print_handle))
+    {
+        status_of_call = psa_call(print_handle, 0, data, 3, NULL, 0);
+        psa_close(print_handle);
+        if (status_of_call != PSA_SUCCESS)
+            return PAL_STATUS_ERROR;
+
+        return PAL_STATUS_SUCCESS;
+    }
+    else
+    {
+        return PAL_STATUS_ERROR;
+    }
+#endif
+}
+
+/**
+    @brief    - This function parses the input string and writes bytes into UART TX FIFO
+    @param    - str      : Input String
+              - data     : Value for format specifier
+    @return   - SUCCESS/FAILURE
+**/
+
+int pal_print_ns(const char *str, int32_t data)
+{
+    int             string_len = 0;
+    const char      *p = str;
+    psa_status_t    status_of_call = PSA_SUCCESS;
+    uart_fn_type_t  uart_fn = UART_PRINT;
+
+    while (*p != '\0')
+    {
+        string_len++;
+        p++;
+    }
+
+    psa_invec data1[3] = {{&uart_fn, sizeof(uart_fn)},
+                          {str, string_len+1},
+                          {&data, sizeof(data)}};
+#if STATELESS_ROT == 1
+    status_of_call = psa_call(DRIVER_UART_HANDLE, 0, data1, 3, NULL, 0);
+    if (status_of_call != PSA_SUCCESS)
+        return PAL_STATUS_ERROR;
+
+    return PAL_STATUS_SUCCESS;
+#else
+    psa_handle_t    print_handle = 0;
+    print_handle = psa_connect(DRIVER_UART_SID, DRIVER_UART_VERSION);
+    if (PSA_HANDLE_IS_VALID(print_handle))
+    {
+        status_of_call = psa_call(print_handle, 0, data1, 3, NULL, 0);
+        psa_close(print_handle);
+        if (status_of_call != PSA_SUCCESS)
+            return PAL_STATUS_ERROR;
+
+        return PAL_STATUS_SUCCESS;
+    }
+    else
+    {
+        return PAL_STATUS_ERROR;
+    }
+#endif
+}
+
+/**
+    @brief           - Initializes an hardware watchdog timer
+    @param           - base_addr       : Base address of the watchdog module
+                     - time_us         : Time in micro seconds
+                     - timer_tick_us   : Number of ticks per micro second
+    @return          - SUCCESS/FAILURE
+**/
+int pal_wd_timer_init_ns(addr_t base_addr, uint32_t time_us, uint32_t timer_tick_us)
+{
+    wd_param_t              wd_param;
+    psa_status_t            status_of_call = PSA_SUCCESS;
+
+    wd_param.wd_fn_type = WD_INIT_SEQ;
+    wd_param.wd_base_addr = base_addr;
+    wd_param.wd_time_us = time_us;
+    wd_param.wd_timer_tick_us = timer_tick_us;
+    psa_invec invec[1] = {{&wd_param, sizeof(wd_param)}};
+
+#if STATELESS_ROT == 1
+    status_of_call = psa_call(DRIVER_WATCHDOG_HANDLE, 0, invec, 1, NULL, 0);
+    if (status_of_call != PSA_SUCCESS)
+        return PAL_STATUS_ERROR;
+
+    return PAL_STATUS_SUCCESS;
+#else
+
+    psa_handle_t            handle = 0;
+    handle = psa_connect(DRIVER_WATCHDOG_SID, DRIVER_WATCHDOG_VERSION);
+    if (PSA_HANDLE_IS_VALID(handle))
+    {
+        status_of_call = psa_call(handle, 0, invec, 1, NULL, 0);
+        psa_close(handle);
+        if (status_of_call != PSA_SUCCESS)
+            return PAL_STATUS_ERROR;
+
+        return PAL_STATUS_SUCCESS;
+    }
+    else
+    {
+        return PAL_STATUS_ERROR;
+    }
+#endif
+
+}
+
+/**
+    @brief           - Enables a hardware watchdog timer
+    @param           - base_addr       : Base address of the watchdog module
+    @return          - SUCCESS/FAILURE
+**/
+int pal_wd_timer_enable_ns(addr_t base_addr)
+{
+    wd_param_t              wd_param;
+    psa_status_t            status_of_call = PSA_SUCCESS;
+
+    wd_param.wd_fn_type = WD_ENABLE_SEQ;
+    wd_param.wd_base_addr = base_addr;
+    wd_param.wd_time_us = 0;
+    wd_param.wd_timer_tick_us = 0;
+    psa_invec invec[1] = {{&wd_param, sizeof(wd_param)}};
+
+#if STATELESS_ROT == 1
+    status_of_call = psa_call(DRIVER_WATCHDOG_HANDLE, 0, invec, 1, NULL, 0);
+    if (status_of_call != PSA_SUCCESS)
+        return PAL_STATUS_ERROR;
+
+    return PAL_STATUS_SUCCESS;
+#else
+    psa_handle_t            handle = 0;
+    handle = psa_connect(DRIVER_WATCHDOG_SID, DRIVER_WATCHDOG_VERSION);
+    if (PSA_HANDLE_IS_VALID(handle))
+    {
+        status_of_call = psa_call(handle, 0, invec, 1, NULL, 0);
+        psa_close(handle);
+        if (status_of_call != PSA_SUCCESS)
+            return PAL_STATUS_ERROR;
+
+        return PAL_STATUS_SUCCESS;
+    }
+    else
+    {
+        return PAL_STATUS_ERROR;
+    }
+#endif
+}
+
+/**
+    @brief           - Disables a hardware watchdog timer
+    @param           - base_addr  : Base address of the watchdog module
+    @return          - SUCCESS/FAILURE
+**/
+int pal_wd_timer_disable_ns(addr_t base_addr)
+{
+    wd_param_t              wd_param;
+    psa_status_t            status_of_call = PSA_SUCCESS;
+
+    wd_param.wd_fn_type = WD_DISABLE_SEQ;
+    wd_param.wd_base_addr = base_addr;
+    wd_param.wd_time_us = 0;
+    wd_param.wd_timer_tick_us = 0;
+    psa_invec invec[1] = {{&wd_param, sizeof(wd_param)}};
+#if STATELESS_ROT == 1
+    status_of_call = psa_call(DRIVER_WATCHDOG_HANDLE, 0, invec, 1, NULL, 0);
+    if (status_of_call != PSA_SUCCESS)
+        return PAL_STATUS_ERROR;
+
+    return PAL_STATUS_SUCCESS;
+#else
+    psa_handle_t            handle = 0;
+
+    handle = psa_connect(DRIVER_WATCHDOG_SID, DRIVER_WATCHDOG_VERSION);
+    if (PSA_HANDLE_IS_VALID(handle))
+    {
+        status_of_call = psa_call(handle, 0, invec, 1, NULL, 0);
+        psa_close(handle);
+        if (status_of_call != PSA_SUCCESS)
+            return PAL_STATUS_ERROR;
+
+        return PAL_STATUS_SUCCESS;
+    }
+    else
+    {
+        return PAL_STATUS_ERROR;
+    }
+#endif
+
+}
+
+/**
+    @brief    - Reads from given non-volatile address.
+    @param    - base    : Base address of nvmem
+                offset  : Offset
+                buffer  : Pointer to source address
+                size    : Number of bytes
+    @return   - SUCCESS/FAILURE
+**/
+int pal_nvmem_read_ns(addr_t base, uint32_t offset, void *buffer, int size)
+{
+    nvmem_param_t   nvmem_param;
+    psa_status_t    status_of_call = PSA_SUCCESS;
+
+    nvmem_param.nvmem_fn_type = NVMEM_READ;
+    nvmem_param.base = base;
+    nvmem_param.offset = offset;
+    nvmem_param.size = size;
+    psa_invec invec[1] = {{&nvmem_param, sizeof(nvmem_param)}};
+    psa_outvec outvec[1] = {{buffer, size}};
+#if STATELESS_ROT == 1
+    status_of_call = psa_call(DRIVER_NVMEM_HANDLE, 0, invec, 1, outvec, 1);
+    if (status_of_call != PSA_SUCCESS)
+        return PAL_STATUS_ERROR;
+
+    return PAL_STATUS_SUCCESS;
+#else
+    psa_handle_t    handle = 0;
+    handle = psa_connect(DRIVER_NVMEM_SID, DRIVER_NVMEM_VERSION);
+    if (PSA_HANDLE_IS_VALID(handle))
+    {
+        status_of_call = psa_call(handle, 0, invec, 1, outvec, 1);
+        psa_close(handle);
+        if (status_of_call != PSA_SUCCESS)
+            return PAL_STATUS_ERROR;
+
+        return PAL_STATUS_SUCCESS;
+    }
+    else
+    {
+        return PAL_STATUS_ERROR;
+    }
+#endif
+
+}
+
+/**
+    @brief    - Writes into given non-volatile address.
+    @param    - base    : Base address of nvmem
+                offset  : Offset
+                buffer  : Pointer to source address
+                size    : Number of bytes
+    @return   - SUCCESS/FAILURE
+**/
+int pal_nvmem_write_ns(addr_t base, uint32_t offset, void *buffer, int size)
+{
+    nvmem_param_t   nvmem_param;
+
+    psa_status_t    status_of_call = PSA_SUCCESS;
+
+    nvmem_param.nvmem_fn_type = NVMEM_WRITE;
+    nvmem_param.base = base;
+    nvmem_param.offset = offset;
+    nvmem_param.size = size;
+    psa_invec invec[2] = {{&nvmem_param, sizeof(nvmem_param)}, {buffer, size}};
+#if STATELESS_ROT == 1
+    status_of_call = psa_call(DRIVER_NVMEM_HANDLE, 0, invec, 2, NULL, 0);
+    if (status_of_call != PSA_SUCCESS)
+        return PAL_STATUS_ERROR;
+
+    return PAL_STATUS_SUCCESS;
+#else
+    psa_handle_t    handle = 0;
+    handle = psa_connect(DRIVER_NVMEM_SID, DRIVER_NVMEM_VERSION);
+    if (PSA_HANDLE_IS_VALID(handle))
+    {
+        status_of_call = psa_call(handle, 0, invec, 2, NULL, 0);
+        psa_close(handle);
+        if (status_of_call != PSA_SUCCESS)
+            return PAL_STATUS_ERROR;
+
+        return PAL_STATUS_SUCCESS;
+    }
+    else
+    {
+        return PAL_STATUS_ERROR;
+    }
+#endif
+}
+
+/**
+ *   @brief    - Terminates the simulation at the end of all tests completion.
+ *               By default, it put cpus into power down mode.
+ *   @param    - void
+ *   @return   - void
+**/
+void pal_terminate_simulation(void)
+{
+    /* Add logic to terminate the simluation */
+
+    while(1)
+    {
+        __asm volatile("WFI");
+    }
+}

--- a/api-tests/platform/targets/tgt_ff_tfm_cs3x0/spe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_ff_tfm_cs3x0/spe/pal_driver_intf.c
@@ -1,0 +1,133 @@
+ /** @file
+  * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
+  * SPDX-License-Identifier : Apache-2.0
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *  http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+ **/
+
+#include "pal_driver_intf.h"
+
+/**
+    @brief    - This function initializes the UART
+    @param    - uart base addr
+    @return   - void
+**/
+void pal_uart_init(uint32_t uart_base_addr)
+{
+    pal_uart_cmsdk_init(uart_base_addr);
+    pal_uart_cmsdk_set_baudrate(25000000/112500);
+}
+
+/**
+    @brief    - This function parses the input string and writes bytes into UART TX FIFO
+    @param    - str      : Input String
+              - data     : Value for format specifier
+**/
+
+void pal_print(const char *str, int32_t data)
+{
+  pal_cmsdk_print(str,data);
+
+}
+
+
+/**
+    @brief    - Writes into given non-volatile address.
+    @param    - base    : Base address of nvmem
+                offset  : Offset
+                buffer  : Pointer to source address
+                size    : Number of bytes
+    @return   - 1/0
+**/
+int pal_nvmem_write(addr_t base, uint32_t offset, void *buffer, int size)
+{
+    return nvmem_write(base, offset, buffer, size);
+}
+
+/**
+    @brief    - Reads from given non-volatile address.
+    @param    - base    : Base address of nvmem
+                offset  : Offset
+                buffer  : Pointer to source address
+                size    : Number of bytes
+    @return   - 1/0
+**/
+int pal_nvmem_read(addr_t base, uint32_t offset, void *buffer, int size)
+{
+    return nvmem_read(base, offset, buffer, size);
+}
+
+
+/**
+    @brief           - Initializes an hardware watchdog timer
+    @param           - base_addr       : Base address of the watchdog module
+                     - time_us         : Time in micro seconds
+                     - timer_tick_us   : Number of ticks per micro second
+    @return          - SUCCESS/FAILURE
+**/
+int pal_wd_timer_init(addr_t base_addr, uint32_t time_us, uint32_t timer_tick_us)
+{
+    return(pal_wd_syswdog_init(base_addr,time_us, timer_tick_us));
+
+}
+
+/**
+    @brief           - Enables a hardware watchdog timer
+    @param           - base_addr       : Base address of the watchdog module
+    @return          - SUCCESS/FAILURE
+**/
+int pal_wd_timer_enable(addr_t base_addr)
+{
+    return(pal_wd_syswdog_enable(base_addr));
+}
+
+/**
+    @brief           - Disables a hardware watchdog timer
+    @param           - base_addr       : Base address of the watchdog module
+    @return          - SUCCESS/FAILURE
+**/
+int pal_wd_timer_disable(addr_t base_addr)
+{
+    return (pal_wd_syswdog_disable(base_addr));
+}
+
+/**
+    @brief           - Checks whether hardware watchdog timer is enabled
+    @param           - base_addr       : Base address of the watchdog module
+    @return          - Enabled : 1, Disabled : 0
+**/
+int pal_wd_timer_is_enabled(addr_t base_addr)
+{
+    return (pal_wd_syswdog_is_enabled(base_addr));
+}
+
+/**
+    @brief   - Trigger interrupt for irq signal assigned to driver partition
+               before return to caller.
+    @param   - void
+    @return  - void
+**/
+void pal_generate_interrupt(void)
+{
+    pal_uart_cmsdk_generate_irq();
+}
+
+/**
+    @brief   - Disable interrupt that was generated using pal_generate_interrupt API.
+    @param   - void
+    @return  - void
+**/
+void pal_disable_interrupt(void)
+{
+    pal_uart_cmsdk_disable_irq();
+}

--- a/api-tests/platform/targets/tgt_ff_tfm_cs3x0/spe/pal_driver_intf.h
+++ b/api-tests/platform/targets/tgt_ff_tfm_cs3x0/spe/pal_driver_intf.h
@@ -1,0 +1,35 @@
+ /** @file
+  * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
+  * SPDX-License-Identifier : Apache-2.0
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *  http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+ **/
+
+#ifndef _PAL_DRIVER_INTF_H_
+#define _PAL_DRIVER_INTF_H_
+
+#include "pal_uart.h"
+#include "pal_nvmem.h"
+#include "pal_wd_syswdog.h"
+
+void pal_uart_init(uint32_t uart_base_addr);
+void pal_print(const char *str, int32_t data);
+int pal_nvmem_write(addr_t base, uint32_t offset, void *buffer, int size);
+int pal_nvmem_read(addr_t base, uint32_t offset, void *buffer, int size);
+int pal_wd_timer_init(addr_t base_addr, uint32_t time_us, uint32_t timer_tick_us);
+int pal_wd_timer_enable(addr_t base_addr);
+int pal_wd_timer_disable(addr_t base_addr);
+int pal_wd_timer_is_enabled(addr_t base_addr);
+void pal_generate_interrupt(void);
+void pal_disable_interrupt(void);
+#endif /* _PAL_DRIVER_INTF_H_ */

--- a/api-tests/platform/targets/tgt_ff_tfm_cs3x0/target.cfg
+++ b/api-tests/platform/targets/tgt_ff_tfm_cs3x0/target.cfg
@@ -1,0 +1,64 @@
+///** @file
+// * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
+// * SPDX-License-Identifier : Apache-2.0
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *  http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+//**/
+
+// UART device info
+uart.num=1;
+uart.0.base = 0x59305000; // UART2_S
+uart.0.size = 0xFFF;
+uart.0.intr_id = 0xFF;
+uart.0.permission = TYPE_READ_WRITE;
+
+// Watchdog device info
+watchdog.num = 1;
+watchdog.0.base = 0x58040000; // APB_WATCHDOG_BASE_S
+watchdog.0.size = 0x2000;
+watchdog.0.intr_id = 0xFF;
+watchdog.0.permission = TYPE_READ_WRITE;
+watchdog.0.num_of_tick_per_micro_sec = 0x19;         //(sys_feq/1000000)
+watchdog.0.timeout_in_micro_sec_low = 0xF4240;      //1.0  sec :  1 * 1000 * 1000
+watchdog.0.timeout_in_micro_sec_medium = 0x1E8480;  //2.0  sec :  2 * 1000 * 1000
+watchdog.0.timeout_in_micro_sec_high = 0x4C4B40;    //5.0  sec :  5 * 1000 * 1000
+watchdog.0.timeout_in_micro_sec_crypto = 0x1312D00; //18.0 sec : 18 * 1000 * 1000
+
+// Range of 1KB Non-volatile memory to preserve data over reset. Ex, NVRAM and FLASH
+nvmem.num =1;
+nvmem.0.start = 0x010FC000;
+nvmem.0.end = 0x010FC3FF;
+nvmem.0.permission = TYPE_READ_WRITE;
+
+// ###################################################################
+// Following Target configuration parameters are required for IPC tests
+// only. Avoid updating them if you are running dev_apis tests.
+// ###################################################################
+
+// Assign free memory range for isolation testing. Choose the addresses
+// for these memory regions such that it follows below condition:
+// nspe_mmio.0.start < server_partition_mmio.0.start < driver_partition_mmio.0.start.
+nspe_mmio.num=1;
+nspe_mmio.0.start = 0x010FC200;
+nspe_mmio.0.end = 0x010FC300;
+nspe_mmio.0.permission = TYPE_READ_WRITE;
+
+server_partition_mmio.num=1;
+server_partition_mmio.0.start = 0x010FC400;
+server_partition_mmio.0.end = 0x010FC500;
+server_partition_mmio.0.permission = TYPE_READ_WRITE;
+
+driver_partition_mmio.num=1;
+driver_partition_mmio.0.start = 0x010FC600;
+driver_partition_mmio.0.end = 0x010FC700;
+driver_partition_mmio.0.permission = TYPE_READ_WRITE;

--- a/api-tests/platform/targets/tgt_ff_tfm_cs3x0/target.cmake
+++ b/api-tests/platform/targets/tgt_ff_tfm_cs3x0/target.cmake
@@ -1,0 +1,74 @@
+#/** @file
+# * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
+# * SPDX-License-Identifier : Apache-2.0
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# *  http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+#**/
+
+# PAL C source files part of NSPE library
+list(APPEND PAL_SRC_C_NSPE )
+
+# PAL ASM source files part of NSPE library
+list(APPEND PAL_SRC_ASM_NSPE )
+
+# PAL C source files part of SPE library - driver partition
+list(APPEND PAL_SRC_C_DRIVER_SP )
+
+# PAL ASM source files part of SPE library - driver partition
+list(APPEND PAL_SRC_ASM_DRIVER_SP )
+
+
+# Listing all the sources required for given target
+if(${SUITE} STREQUAL "IPC")
+    list(APPEND PAL_SRC_C_NSPE
+        # driver functionalities are implemented as RoT-services
+        # and secure and non-secure clients will call to these RoT-services to get appropriate driver services.
+        ${PSA_ROOT_DIR}/platform/targets/${TARGET}/nspe/pal_driver_ipc_intf.c
+    )
+    list(APPEND PAL_SRC_C_DRIVER_SP
+        # Driver files will be compiled as part of driver partition
+        ${PSA_ROOT_DIR}/platform/targets/${TARGET}/spe/pal_driver_intf.c
+        ${PSA_ROOT_DIR}/platform/drivers/nvmem/pal_nvmem.c
+        ${PSA_ROOT_DIR}/platform/drivers/uart/cmsdk/pal_uart.c
+        ${PSA_ROOT_DIR}/platform/drivers/watchdog/syswatchdog/pal_wd_syswdog.c
+    )
+endif()
+
+if((${SUITE} STREQUAL "CRYPTO") OR
+   (${SUITE} STREQUAL "STORAGE") OR
+   (${SUITE} STREQUAL "PROTECTED_STORAGE") OR
+   (${SUITE} STREQUAL "INTERNAL_TRUSTED_STORAGE") OR
+   (${SUITE} STREQUAL "INITIAL_ATTESTATION"))
+    message(FATAL_ERROR "For PSA API - use -DTARGET=tgt_dev_apis_tfm_an521 instead")
+endif()
+
+# Create NSPE library
+add_library(${PSA_TARGET_PAL_NSPE_LIB} STATIC ${PAL_SRC_C_NSPE} ${PAL_SRC_ASM_NSPE})
+
+# PSA Include directories
+foreach(psa_inc_path ${PSA_INCLUDE_PATHS})
+    target_include_directories(${PSA_TARGET_PAL_NSPE_LIB} PRIVATE ${psa_inc_path})
+endforeach()
+
+list(APPEND PAL_DRIVER_INCLUDE_PATHS
+    ${PSA_ROOT_DIR}/platform/drivers/nvmem
+    ${PSA_ROOT_DIR}/platform/drivers/uart/cmsdk
+    ${PSA_ROOT_DIR}/platform/drivers/watchdog/syswatchdog
+)
+
+target_include_directories(${PSA_TARGET_PAL_NSPE_LIB} PRIVATE
+    ${PAL_DRIVER_INCLUDE_PATHS}
+    ${PSA_ROOT_DIR}/platform/targets/common/nspe
+    ${PSA_ROOT_DIR}/platform/targets/common/nspe/crypto
+    ${PSA_ROOT_DIR}/platform/targets/${TARGET}/nspe
+)

--- a/api-tests/tools/cmake/compiler/ARMCLANG.cmake
+++ b/api-tests/tools/cmake/compiler/ARMCLANG.cmake
@@ -1,5 +1,5 @@
 #/** @file
-# * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+# * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
 # * SPDX-License-Identifier : Apache-2.0
 # *
 # * Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,11 +51,13 @@ foreach(_LNG IN ITEMS "C" "ASM")
 endforeach()
 
 if(${CPU_ARCH} STREQUAL armv7m)
-	set(TARGET_SWITCH "-march=armv7-m")
+    set(TARGET_SWITCH "-march=armv7-m")
 elseif(${CPU_ARCH} STREQUAL armv8m_ml)
-	set(TARGET_SWITCH "-march=armv8-m.main -mcmse")
+    set(TARGET_SWITCH "-march=armv8-m.main -mcmse")
 elseif(${CPU_ARCH} STREQUAL armv8m_bl)
-	set(TARGET_SWITCH "-march=armv8-m.base -mcmse")
+    set(TARGET_SWITCH "-march=armv8-m.base -mcmse")
+elseif(${CPU_ARCH} STREQUAL armv81m_ml)
+    set(TARGET_SWITCH "-march=armv8.1-m.main -mcmse")
 endif()
 
 set(CMAKE_C_FLAGS              "--target=arm-arm-none-eabi ${TARGET_SWITCH} -g -Wall -Werror -Wextra -fshort-enums -fshort-wchar -funsigned-char -fdata-sections -ffunction-sections -mno-unaligned-access -mfpu=none")

--- a/api-tests/tools/cmake/compiler/GNUARM.cmake
+++ b/api-tests/tools/cmake/compiler/GNUARM.cmake
@@ -1,5 +1,5 @@
 #/** @file
-# * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+# * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
 # * SPDX-License-Identifier : Apache-2.0
 # *
 # * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,41 +21,43 @@ set(CMKE_SYSTEM_PROCESSOR ARM)
 set(_C_TOOLCHAIN_NAME arm-none-eabi-gcc)
 
 if(WIN32)
-	if (NOT DEFINED GNUARM_PATH)
-		set(GNUARM_PATH "C:" CACHE PATH "Install directory for GNUARM Compiler")
-	endif()
+    if (NOT DEFINED GNUARM_PATH)
+        set(GNUARM_PATH "C:" CACHE PATH "Install directory for GNUARM Compiler")
+    endif()
 else(WIN32)
-	if (NOT DEFINED GNUARM_PATH)
-		set(GNUARM_PATH "/" CACHE PATH "Install directory for GNUARM Compiler")
-	endif()
+    if (NOT DEFINED GNUARM_PATH)
+        set(GNUARM_PATH "/" CACHE PATH "Install directory for GNUARM Compiler")
+    endif()
 endif(WIN32)
 
 find_program(
-	_C_TOOLCHAIN_PATH
-	${_C_TOOLCHAIN_NAME}
-	PATHS env PATH
-	HINTS ${GNUARM_PATH}
-	HINTS bin
+    _C_TOOLCHAIN_PATH
+    ${_C_TOOLCHAIN_NAME}
+    PATHS env PATH
+    HINTS ${GNUARM_PATH}
+    HINTS bin
 )
 
 if(_C_TOOLCHAIN_PATH STREQUAL "_C_TOOLCHAIN_PATH-NOTFOUND")
         message(FATAL_ERROR "[PSA] : Couldn't find ${_C_TOOLCHAIN_NAME}."
-			    " Either put ${_C_TOOLCHAIN_NAME} on the PATH or set GNUARM_PATH set properly.")
+                " Either put ${_C_TOOLCHAIN_NAME} on the PATH or set GNUARM_PATH set properly.")
 endif()
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
 foreach(_LNG IN ITEMS "C" "ASM")
-	set(CMAKE_${_LNG}_COMPILER ${_C_TOOLCHAIN_PATH})
-	message(STATUS "[PSA] : ${_LNG}  compiler used '${CMAKE_${_LNG}_COMPILER}'")
+    set(CMAKE_${_LNG}_COMPILER ${_C_TOOLCHAIN_PATH})
+    message(STATUS "[PSA] : ${_LNG}  compiler used '${CMAKE_${_LNG}_COMPILER}'")
 endforeach()
 
 if(${CPU_ARCH} STREQUAL armv7m)
-	set(TARGET_SWITCH "-march=armv7-m")
+    set(TARGET_SWITCH "-march=armv7-m")
 elseif(${CPU_ARCH} STREQUAL armv8m_ml)
-	set(TARGET_SWITCH "-march=armv8-m.main -mcmse")
+    set(TARGET_SWITCH "-march=armv8-m.main -mcmse")
 elseif(${CPU_ARCH} STREQUAL armv8m_bl)
-	set(TARGET_SWITCH "-march=armv8-m.base -mcmse")
+    set(TARGET_SWITCH "-march=armv8-m.base -mcmse")
+elseif(${CPU_ARCH} STREQUAL armv81m_ml)
+    set(TARGET_SWITCH "-march=armv8.1-m.main -mcmse")
 endif()
 
 set(CMAKE_C_FLAGS          "${TARGET_SWITCH} -g -Wall -Werror -Wextra -fdata-sections -ffunction-sections -mno-unaligned-access")

--- a/api-tests/tools/scripts/gen_tests_list.py
+++ b/api-tests/tools/scripts/gen_tests_list.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #/** @file
-# * Copyright (c) 2019-2021, Arm Limited or its affiliates. All rights reserved.
+# * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
 # * SPDX-License-Identifier : Apache-2.0
 # *
 # * Licensed under the Apache License, Version 2.0 (the "License");
@@ -72,23 +72,23 @@ def gen_test_list():
 				    (int(line[6:9]) <= suite_test_end_number)):
 					if (panic_tests_included == 0):
 						if (tests_coverage == "ALL"):
-							if (("panic" not in line) and ("failing" not in line)):
+							if (("panic" not in line) and ("failing" not in line) and ("skip" not in line)):
 								o_f.write(line)
-							if (("panic" not in line) and ("failing" in line)):
+							if (("panic" not in line) and ("failing" in line) and ("skip" not in line)):
 								o_f.write(line[0:line.find(',')]+'\n')
 						if (tests_coverage == "PASS"):
-							if (("panic" not in line) and ("failing" not in line)):
+							if (("panic" not in line) and ("failing" not in line) and ("skip" not in line)):
 								o_f.write(line)
 					if (panic_tests_included == 1):
 						if (tests_coverage == "ALL"):
-							if (("panic" not in line) and ("failing" not in line)):
+							if (("panic" not in line) and ("failing" not in line) and ("skip" not in line)):
 								o_f.write(line)
 							else:
 								o_f.write(line[0:line.find(',')]+'\n')
 						if (tests_coverage == "PASS"):
-							if (("panic" not in line) and ("failing" not in line)):
+							if (("panic" not in line) and ("failing" not in line) and ("skip" not in line)):
 								o_f.write(line)
-							if (("panic" in line) and ("failing" not in line)):
+							if (("panic" in line) and ("failing" not in line) and ("skip" not in line)):
 								o_f.write(line[0:line.find(',')]+'\n')
 
 def gen_test_entry_info():

--- a/api-tests/val/nspe/pal_interfaces_ns.h
+++ b/api-tests/val/nspe/pal_interfaces_ns.h
@@ -1,5 +1,6 @@
 /** @file
  * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
+ * Copyright 2023 NXP
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -126,4 +127,18 @@ void pal_terminate_simulation(void);
  *   @return   - SUCCESS/FAILURE
 **/
 int pal_system_reset(void);
+
+/**
+ *   @brief    - Sets the custom test list buffer
+ *   @param    - custom_test_list : Custom test list buffer 
+     @return   - void
+**/
+void pal_set_custom_test_list(char *custom_test_list);
+
+/**
+ *   @brief    - Tells if a test is enabled on platform
+ *   @param    - test_id : Test ID
+ *   @return   - TRUE/FALSE
+**/
+bool_t pal_is_test_enabled(test_id_t test_id);
 #endif

--- a/api-tests/val/nspe/val_dispatcher.c
+++ b/api-tests/val/nspe/val_dispatcher.c
@@ -89,7 +89,7 @@ val_status_t val_test_load(test_id_t *test_id, test_id_t test_id_prev)
 
     for(; test_info->test_id != VAL_INVALID_TEST_ID; test_info++)
     {
-        if (pal_is_test_enabled(VAL_GET_TEST_NUM(test_info->test_id)))
+        if (pal_is_test_enabled(test_info->test_id))
         {
             *test_id = test_info->test_id;
             g_test_info_addr = (addr_t) test_info->entry_addr;

--- a/api-tests/val/nspe/val_dispatcher.c
+++ b/api-tests/val/nspe/val_dispatcher.c
@@ -60,6 +60,42 @@ __attribute__((unused)) static void val_print_api_version(void)
 #endif
 }
 
+static val_test_info_t g_test_list[] = {
+#include "test_entry_list.inc"
+                                  {VAL_INVALID_TEST_ID, NULL}
+                              };
+
+/**
+    @brief        - This function returns the IDs list of available tests
+    @param        - test_id_list : Buffer allocated by caller
+                  - size : Size of test_id_list
+    @return       - If test_id_list is NULL, the required size of test_id_list
+                    else if size is too small -1 
+                    else the actual size of test_id_list
+**/
+size_t val_get_test_list(uint32_t *test_id_list, size_t size)
+{
+
+    val_test_info_t *test_info = &g_test_list[0];
+    size_t test_list_size = sizeof(g_test_list)/sizeof(g_test_list[0]) - 1;
+
+    if (!test_id_list)
+        return test_list_size;
+
+    if (size < test_list_size)
+        return -1;
+
+    test_list_size = 0;
+
+    for(; test_info->test_id != VAL_INVALID_TEST_ID; test_info++)
+    {
+        *test_id_list++ = test_info->test_id;
+        test_list_size++;
+    }
+
+    return test_list_size;
+}
+
 /**
     @brief        - This function reads the test ELFs from RAM or secondary storage and loads into
                     system memory
@@ -69,11 +105,7 @@ __attribute__((unused)) static void val_print_api_version(void)
 **/
 val_status_t val_test_load(test_id_t *test_id, test_id_t test_id_prev)
 {
-    val_test_info_t test_list[] = {
-#include "test_entry_list.inc"
-                                  {VAL_INVALID_TEST_ID, NULL}
-                                  };
-    val_test_info_t *test_info = &test_list[0];
+    val_test_info_t *test_info = &g_test_list[0];
 
     if (test_id_prev != VAL_INVALID_TEST_ID)
     {

--- a/secure-debug/tools/cmake/compiler/ARMCLANG.cmake
+++ b/secure-debug/tools/cmake/compiler/ARMCLANG.cmake
@@ -1,5 +1,5 @@
 #/** @file
-# * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+# * Copyright (c) 2021-2023, Arm Limited or its affiliates. All rights reserved.
 # * SPDX-License-Identifier : Apache-2.0
 # *
 # * Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,6 +56,8 @@ elseif(${CPU_ARCH} STREQUAL armv8m_ml)
 	set(TARGET_SWITCH "-march=armv8-m.main -mcmse")
 elseif(${CPU_ARCH} STREQUAL armv8m_bl)
 	set(TARGET_SWITCH "-march=armv8-m.base -mcmse")
+elseif(${CPU_ARCH} STREQUAL armv81m_ml)
+	set(TARGET_SWITCH "-march=armv8.1-m.main -mcmse")
 endif()
 
 set(CMAKE_C_FLAGS              "--target=arm-arm-none-eabi ${TARGET_SWITCH} -g -Wall -Werror -Wextra -fshort-enums -fshort-wchar -funsigned-char -fdata-sections -ffunction-sections -mno-unaligned-access -mfpu=none")

--- a/secure-debug/tools/cmake/compiler/GNUARM.cmake
+++ b/secure-debug/tools/cmake/compiler/GNUARM.cmake
@@ -1,5 +1,5 @@
 #/** @file
-# * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+# * Copyright (c) 2021-2023, Arm Limited or its affiliates. All rights reserved.
 # * SPDX-License-Identifier : Apache-2.0
 # *
 # * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,41 +21,43 @@ set(CMKE_SYSTEM_PROCESSOR ARM)
 set(_C_TOOLCHAIN_NAME arm-none-eabi-gcc)
 
 if(WIN32)
-	if (NOT DEFINED GNUARM_PATH)
-		set(GNUARM_PATH "C:" CACHE PATH "Install directory for GNUARM Compiler")
-	endif()
+    if (NOT DEFINED GNUARM_PATH)
+        set(GNUARM_PATH "C:" CACHE PATH "Install directory for GNUARM Compiler")
+    endif()
 else(WIN32)
-	if (NOT DEFINED GNUARM_PATH)
-		set(GNUARM_PATH "/" CACHE PATH "Install directory for GNUARM Compiler")
-	endif()
+    if (NOT DEFINED GNUARM_PATH)
+        set(GNUARM_PATH "/" CACHE PATH "Install directory for GNUARM Compiler")
+    endif()
 endif(WIN32)
 
 find_program(
-	_C_TOOLCHAIN_PATH
-	${_C_TOOLCHAIN_NAME}
-	PATHS env PATH
-	HINTS ${GNUARM_PATH}
-	HINTS bin
+    _C_TOOLCHAIN_PATH
+    ${_C_TOOLCHAIN_NAME}
+    PATHS env PATH
+    HINTS ${GNUARM_PATH}
+    HINTS bin
 )
 
 if(_C_TOOLCHAIN_PATH STREQUAL "_C_TOOLCHAIN_PATH-NOTFOUND")
         message(FATAL_ERROR "[PSA] : Couldn't find ${_C_TOOLCHAIN_NAME}."
-			    " Either put ${_C_TOOLCHAIN_NAME} on the PATH or set GNUARM_PATH set properly.")
+                " Either put ${_C_TOOLCHAIN_NAME} on the PATH or set GNUARM_PATH set properly.")
 endif()
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
 foreach(_LNG IN ITEMS "C" "ASM")
-	set(CMAKE_${_LNG}_COMPILER ${_C_TOOLCHAIN_PATH})
-	message(STATUS "[PSA] : ${_LNG}  compiler used '${CMAKE_${_LNG}_COMPILER}'")
+    set(CMAKE_${_LNG}_COMPILER ${_C_TOOLCHAIN_PATH})
+    message(STATUS "[PSA] : ${_LNG}  compiler used '${CMAKE_${_LNG}_COMPILER}'")
 endforeach()
 
 if(${CPU_ARCH} STREQUAL armv7m)
-	set(TARGET_SWITCH "-march=armv7-m")
+    set(TARGET_SWITCH "-march=armv7-m")
 elseif(${CPU_ARCH} STREQUAL armv8m_ml)
-	set(TARGET_SWITCH "-march=armv8-m.main -mcmse")
+    set(TARGET_SWITCH "-march=armv8-m.main -mcmse")
 elseif(${CPU_ARCH} STREQUAL armv8m_bl)
-	set(TARGET_SWITCH "-march=armv8-m.base -mcmse")
+    set(TARGET_SWITCH "-march=armv8-m.base -mcmse")
+elseif(${CPU_ARCH} STREQUAL armv81m_ml)
+    set(TARGET_SWITCH "-march=armv8.1-m.main -mcmse")
 endif()
 
 set(CMAKE_C_FLAGS          "${TARGET_SWITCH} -g -Wall -Werror -Wextra -fdata-sections -ffunction-sections -mno-unaligned-access")


### PR DESCRIPTION
**Context**
As the list of test cases is built at compile time, if some test cases need to be disabled, custom NSPE binaries and a custom test executable need to be built.
This is the case when
- the test suite does not match the capabilities of the implementation
- the implementation and the test suite are incompatible (updated the test suite or implementation under development)

**Improvement**
Implement a mechanism to customize the list of test cases at runtime.
This mechanism defines the list of runable test cases among the list of test cases implemented by the test suite.
Using to this mechanism, generic NSPE binaries can be used for platforms with different capabilities.

**This PR**
Added 2 PAL functions:
pal_set_custom_test_list() - Sets the custom test list buffer
pal_is_test_enabled() - Tells if a test is enabled on platform

A platform can provide the custom test case list by calling pal_set_custom_test_list().
The Validation Abstraction Layer (VAL) calls pal_is_test_enabled() to check if a test case is enabled and eventually runs it.
All test cases are enabled if no custom list of test cases is provided.
Platforms that do not need to implement this mechanism do not have to implement these 2 PAL functions.